### PR TITLE
Fix Windows issue with files being exclusively owned by shex once opened

### DIFF
--- a/hex_editor.cpp
+++ b/hex_editor.cpp
@@ -68,7 +68,7 @@ void hex_editor::set_focus()
 	emit update_status_text(get_status_text());
 	hex->setFocus();
 	buffer->set_active();
-	emit update_save_state(0);
+	update_save_state(0);
 	update_window();
 }
 
@@ -135,7 +135,7 @@ void hex_editor::goto_diff(bool direction)
 	if(offset != -1){
 		goto_offset(buffer->pc_to_snes(offset));
 	}else{
-		update_status_text("No differences found!");
+		emit update_status_text("No differences found!");
 	}
 }
 
@@ -410,7 +410,7 @@ void hex_editor::count(QString find, bool mode)
 	if(result < 0){
 		search_error(result, find);
 	}else{
-		update_status_text(QString::number(result) + " Results found for " + find);
+		emit update_status_text(QString::number(result) + " Results found for " + find);
 	}
 
 }
@@ -458,7 +458,7 @@ void hex_editor::replace_all(QString find, QString replace, bool mode)
 	if(result < 0){
 		search_error(result, find, replace);
 	}else{
-		update_status_text(QString::number(result) + " Results found for " + find);
+		emit update_status_text(QString::number(result) + " Results found for " + find);
 	}
 	update_save_state(1);
 }
@@ -680,11 +680,11 @@ void hex_editor::set_offset(int o)
 void hex_editor::search_error(int error, QString find, QString replace_with)
 {
 	if(error == ROM_buffer::INVALID_REPLACE){
-		update_status_text("Error: Invalid replace hex string: " + replace_with);
+		emit update_status_text("Error: Invalid replace hex string: " + replace_with);
 	}else if(error == ROM_buffer::INVALID_FIND){
-		update_status_text("Error: Invalid find hex string: " + find);
+		emit update_status_text("Error: Invalid find hex string: " + find);
 	}else if(error == ROM_buffer::NOT_FOUND){
-		update_status_text("Error: String " + find + " not found.");
+		emit update_status_text("Error: String " + find + " not found.");
 	}
 }
 

--- a/rom_buffer.cpp
+++ b/rom_buffer.cpp
@@ -25,13 +25,13 @@ void ROM_buffer::remove_copy_header()
 void ROM_buffer::open(QString path)
 {
 	ROM.setFileName(path);
-    ROM.open(QFile::ReadOnly);
+	ROM.open(QFile::ReadOnly);
 	buffer = ROM.readAll();
 	if(ROM.size() < 0x8000){
 		ROM_error = "The ROM is too small to be valid.";
 		return;
 	}
-    ROM.close();
+	ROM.close();
 	analyze();
 }
 
@@ -41,14 +41,14 @@ void ROM_buffer::save(QString path)
 	if(path != "" && path != info.absolutePath()){
 		ROM.setFileName(path);	
 	}
-    ROM.open(QFile::WriteOnly);
+	ROM.open(QFile::WriteOnly);
 	if(header_size()){
 		ROM.seek(0);
 		ROM.write(header_buffer);
 	}
 	ROM.seek(header_size());
 	ROM.write(buffer);
-    ROM.close();
+	ROM.close();
 }
 
 void ROM_buffer::initialize_undo(QUndoGroup *undo_group)

--- a/rom_buffer.cpp
+++ b/rom_buffer.cpp
@@ -24,16 +24,14 @@ void ROM_buffer::remove_copy_header()
 
 void ROM_buffer::open(QString path)
 {
-	if(ROM.isOpen()){
-		ROM.close();
-	}
 	ROM.setFileName(path);
-	ROM.open(QFile::ReadWrite);
+    ROM.open(QFile::ReadOnly);
 	buffer = ROM.readAll();
 	if(ROM.size() < 0x8000){
 		ROM_error = "The ROM is too small to be valid.";
 		return;
 	}
+    ROM.close();
 	analyze();
 }
 
@@ -41,16 +39,16 @@ void ROM_buffer::save(QString path)
 {
 	QFileInfo info(ROM);
 	if(path != "" && path != info.absolutePath()){
-		ROM.close();
 		ROM.setFileName(path);	
-		ROM.open(QFile::ReadWrite);
 	}
+    ROM.open(QFile::WriteOnly);
 	if(header_size()){
 		ROM.seek(0);
 		ROM.write(header_buffer);
 	}
 	ROM.seek(header_size());
 	ROM.write(buffer);
+    ROM.close();
 }
 
 void ROM_buffer::initialize_undo(QUndoGroup *undo_group)


### PR DESCRIPTION
Currently when opening a rom in shex, shex will keep the QFile object open.
This, on Windows, causes the rom to be impossible to open in certain other programs (e.g. BizHawk), with an error like "This file is already open in another process (shex.exe)".

Since keeping the QFile object open is not necessary, the fix for this issue is simply to close the QFile after reading all of its data and then re-opening it only once we want to write into it. 

This patch is simple and it doesn't do any error checking on open/read/write, because the code that was already existing didn't do any error checking either.

This patch also fixes a few missing or misplaced `emit` keywords as reported by QtCreator.